### PR TITLE
Fix #143

### DIFF
--- a/src/SimpleThings/EntityAudit/Metadata/MetadataFactory.php
+++ b/src/SimpleThings/EntityAudit/Metadata/MetadataFactory.php
@@ -29,7 +29,9 @@ class MetadataFactory
 
     public function __construct($auditedEntities)
     {
-        $this->auditedEntities = array_flip($auditedEntities);
+        $this->auditedEntities = array_flip(array_filter($auditedEntities, function($record) {
+            return is_string($record) || is_int($record);
+        }));
     }
 
     public function isAudited($entity)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no
| Fixed tickets | #143 

For some reason, the `$auditedEntities` contained 'null' elements. The `$auditedEntites` parameter is set by the `doctrine-orm-admin-bundle` and for some reason it adds `null` records to the array. With the `array_filter` calls, only the records that are strings or integers are collected, ignoring the unsupported types of `array_flip`.

I do not know if this is the correct fix, or whether the `doctrine-orm-admin-bundle` should be updated to fix the null results they generate.