### PR TITLE
Fix BC break - username should not be null

### DIFF
--- a/src/SimpleThings/EntityAudit/AuditConfiguration.php
+++ b/src/SimpleThings/EntityAudit/AuditConfiguration.php
@@ -155,7 +155,7 @@ class AuditConfiguration
     {
         $callable = $this->usernameCallable;
 
-        return $callable ? $callable() : null;
+        return $callable ? $callable() : "";
     }
 
     public function setUsernameCallable($usernameCallable)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no
| Fixed tickets | #286

https://github.com/simplethings/EntityAuditBundle/commit/4640b8ed8fcab3e40d30b6f45253285d5faeb421 introduced a BC break, forcing users to run a migration on their audit tables.

This bugfix should **not** be ported to master.