### PR TITLE
Add "type": "symfony-bundle" in composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "simplethings/entity-audit-bundle",
+    "type": "symfony-bundle",
     "license": "LGPL-2.1",
     "keywords": [
         "Persistence",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no

This allow to Symfony Flex to enable it on bundles.php