### PR TITLE
Revision table now mirrors the original columns more accurately.

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
@@ -75,8 +75,8 @@ class CreateSchemaListener implements EventSubscriber
         foreach ($entityTable->getColumns() as $column) {
             /* @var Column $column */
             $revisionTable->addColumn($column->getName(), $column->getType()->getName(), array_merge(
-                $column->toArray(),
-                array('notnull' => false, 'autoincrement' => false)
+                array('notnull' => false, 'autoincrement' => false),
+                $column->toArray()
             ));
         }
         $revisionTable->addColumn($this->config->getRevisionFieldName(), $this->config->getRevisionIdFieldType());

--- a/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/CreateSchemaListener.php
@@ -75,8 +75,9 @@ class CreateSchemaListener implements EventSubscriber
         foreach ($entityTable->getColumns() as $column) {
             /* @var Column $column */
             $revisionTable->addColumn($column->getName(), $column->getType()->getName(), array_merge(
-                array('notnull' => false, 'autoincrement' => false),
-                $column->toArray()
+                array('notnull' => false),
+                $column->toArray(),
+                array('autoincrement' => false)
             ));
         }
         $revisionTable->addColumn($this->config->getRevisionFieldName(), $this->config->getRevisionIdFieldType());


### PR DESCRIPTION
Changed the revision table columns to override the default properties in order to better mirror the original table.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no
| Fixed tickets | #318 

All columns on the revision table were being set to "not null", which was causing conflicts when the original table had nullable fields. This PR makes sure that all of the column settings are carried over to the revision table.